### PR TITLE
fix: add necessary trustHost flag to auth config

### DIFF
--- a/app/api/auth/[...nextauth]/auth.ts
+++ b/app/api/auth/[...nextauth]/auth.ts
@@ -9,6 +9,7 @@ export const {
     handlers: { GET, POST },
     auth,
 } = NextAuth({
+    trustHost: true,
     providers: [
         Zitadel({
             clientId: process.env.ZITADEL_CLIENT_ID,


### PR DESCRIPTION
This pull request adds a necessary property to the auth configuration.