### PR TITLE
bugfix: ensure unique keys in postlist in replies display

### DIFF
--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -28,8 +28,8 @@ export default async function Detail({
           </div>
 
           {replies &&
-            replies.data?.map((post: Post, index: number) => (
-              <Reply key='index' reply={post}></Reply>
+            replies.data?.map((post: Post) => (
+              <Reply key={post.id} reply={post}></Reply>
             ))}
         </div>
       )}

--- a/components/post-list/post-list.tsx
+++ b/components/post-list/post-list.tsx
@@ -57,8 +57,8 @@ export default function PostList({ postsPaginatedResult, queryParams }: Props) {
 
   return (
     <>
-      {posts.map((post, index: number) => (
-        <div key={index}>
+      {posts.map((post) => (
+        <div key={post.id}>
           <SinglePost post={post} />
           <div className='pt-l'></div>
         </div>


### PR DESCRIPTION
## Overview

This PR addresses the issue where the `like` state incorrectly carries over from one post to another when a new post is created and added to the top of the list. The root cause was identified as the misuse of array indices as keys in the rendering of posts, which interfered with React's reconciliation process and led to state leakage between post components.

## Changes Made

- **Refactor Key Assignment in `PostList`**: Updated the key used for each post in the `PostList` component from the array index to a unique identifier, `post.id`, ensuring that each post is uniquely and consistently identified across renders.

### Before

Posts were mapped using their index as the key, which caused issues with state persistence:

```jsx
{posts.map((post, index) => (
  <div key={index}>
    <SinglePost post={post} />
    <div className='pt-l'></div>
  </div>
))}

```
### After
```jsx
{posts.map((post) => (
  <div key={post.id}>
    <SinglePost post={post} />
    <div className='pt-l'></div>
  </div>
))}
