### PR TITLE
feat: add aria-live to refresh button

### DIFF
--- a/app/api/actions/post.actions.ts
+++ b/app/api/actions/post.actions.ts
@@ -162,3 +162,7 @@ const revalidatePosts = (userId: string) => {
   revalidateTag(`creators-${userId}`);
   revalidateTag(`likedBy-${userId}`);
 };
+
+export const revalidateHomePosts = () => {
+  revalidatePath('/', 'page');
+};

--- a/components/_shared/interaction/interaction-strip.tsx
+++ b/components/_shared/interaction/interaction-strip.tsx
@@ -4,8 +4,8 @@ import { Comment } from '@/components/_shared/interaction/comment';
 import { CopyLink } from '@/components/_shared/interaction/copy-link';
 import { DeleteUserPost } from '@/components/_shared/interaction/delete';
 import { Like } from '@/components/_shared/interaction/like';
+import { useAuthSession } from '@/utils/hooks/swr-hooks';
 import { Post } from '@/utils/models';
-import { useSession } from 'next-auth/react';
 
 export const InteractionStrip = ({
   post,
@@ -14,7 +14,7 @@ export const InteractionStrip = ({
   post: Post;
   reduced?: boolean;
 }) => {
-  const { data: session } = useSession();
+  const { session: session } = useAuthSession();
   const isCreator = session?.user.id === post.creator.id;
 
   return (

--- a/components/_shared/interaction/like.tsx
+++ b/components/_shared/interaction/like.tsx
@@ -25,7 +25,9 @@ export const Like = ({ post }: { post: Post }) => {
   const like = async () => {
     setLikedBySelf(!likedBySelf);
     setLikes(likedBySelf ? likes - 1 : likes + 1);
+  };
 
+  const likeOnServer = async () => {
     try {
       await UpdateLike(
         post.id,
@@ -40,12 +42,14 @@ export const Like = ({ post }: { post: Post }) => {
   };
 
   return (
-    <LikeButton
-      count={likes}
-      labels={likeLabels}
-      isAlreadyLiked={likedBySelf}
-      onClick={like}
-      testid='single-post-like'
-    ></LikeButton>
+    <div onClick={likeOnServer}>
+      <LikeButton
+        count={likes}
+        labels={likeLabels}
+        isAlreadyLiked={likedBySelf}
+        onClick={like}
+        testid='single-post-like'
+      ></LikeButton>
+    </div>
   );
 };

--- a/components/_shared/interaction/like.tsx
+++ b/components/_shared/interaction/like.tsx
@@ -36,8 +36,10 @@ export const Like = ({ post }: { post: Post }) => {
       );
       reloadData();
     } catch (error) {
-      setLikedBySelf(post.likedBySelf ?? false);
-      setLikes(post.likedBySelf ? likes - 1 : likes + 1);
+      setTimeout(() => {
+        setLikedBySelf(post.likedBySelf ?? false);
+        setLikes(post.likedBySelf ? likes - 1 : likes + 1);
+      }, 1000);
     }
   };
 

--- a/components/_shared/interaction/like.tsx
+++ b/components/_shared/interaction/like.tsx
@@ -2,9 +2,9 @@
 
 import { UpdateLike } from '@/actions/post.actions';
 import { UserPostsContext } from '@/post/user-posts-context';
+import { useAuthSession } from '@/utils/hooks/swr-hooks';
 import { Post } from '@/utils/models';
 import { LikeButton } from 'clada-storybook';
-import { useSession } from 'next-auth/react';
 import { useContext, useState } from 'react';
 
 const likeLabels = {
@@ -20,7 +20,7 @@ export const Like = ({ post }: { post: Post }) => {
 
   const { reloadData, isProvided } = useContext(UserPostsContext);
 
-  const { data: session } = useSession();
+  const { session: session } = useAuthSession();
 
   const like = async () => {
     setLikedBySelf(!likedBySelf);

--- a/components/post/create-content.tsx
+++ b/components/post/create-content.tsx
@@ -33,8 +33,6 @@ export const CreateContent = ({
   const create = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    useAuthSession;
-
     const formData = new FormData();
 
     if (selectedFile) {

--- a/components/post/post-list/post-list.tsx
+++ b/components/post/post-list/post-list.tsx
@@ -7,8 +7,8 @@ import { useEffect, useState } from 'react';
 // inspiration from https://medium.com/@ferlat.simon/infinite-scroll-with-nextjs-server-actions-a-simple-guide-76a894824cfd
 import { CreatePost as FirstPost } from '@/post/create-post';
 import PostSkeleton from '@/post/skeleton/post-skeleton';
+import { useAuthSession } from '@/utils/hooks/swr-hooks';
 import { IconButton, RepostIcon } from 'clada-storybook';
-import { useSession } from 'next-auth/react';
 import { useInView } from 'react-intersection-observer';
 
 export default function PostList({
@@ -36,7 +36,7 @@ export default function PostList({
 
   const { ref, inView } = useInView();
 
-  const { data: session } = useSession();
+  const { session: session } = useAuthSession();
 
   useEffect(() => {
     const eventSource = new EventSource(`${Config.apiUrl}/posts/_sse`);
@@ -115,7 +115,7 @@ export default function PostList({
 
   return (
     <>
-      {staleEventSourcePosts.length > 0 && (
+      {showRefresh && staleEventSourcePosts.length > 0 && (
         <div className='sticky top-[84px] z-50'>
           <div className='flex justify-around mt-[-32px]'>
             <div

--- a/components/post/post-list/post-list.tsx
+++ b/components/post/post-list/post-list.tsx
@@ -55,11 +55,15 @@ export default function PostList({
   useEffect(() => {
     const eventSource = new EventSource(`${Config.apiUrl}/posts/_sse`);
 
-    const handlePostUpdate = (postId: string) => {
-      if (posts.find((x) => x.id === postId)) {
+    const handlePostUpdate = (data: { postId: string; userId: string }) => {
+      if (
+        data.userId === session?.user.id &&
+        posts.find((x) => x.id === data.postId)
+      ) {
         revalidateHomePosts();
+      } else {
+        sessionStorage.setItem('shouldRevalidate', 'true');
       }
-      sessionStorage.setItem('shouldRevalidate', 'true');
     };
 
     eventSource.addEventListener('postCreated', (e) => {
@@ -78,17 +82,18 @@ export default function PostList({
       sessionStorage.setItem('shouldRevalidate', 'true');
     });
 
-    eventSource.addEventListener('postLiked', (e) =>
-      handlePostUpdate(JSON.parse(e.data).postId)
-    );
+    eventSource.addEventListener('postLiked', (e) => {
+      console.log(JSON.parse(e.data));
+      handlePostUpdate(JSON.parse(e.data));
+    });
     eventSource.addEventListener('postUnliked', (e) =>
-      handlePostUpdate(JSON.parse(e.data).postId)
+      handlePostUpdate(JSON.parse(e.data))
     );
     eventSource.addEventListener('postDeleted', (e) =>
-      handlePostUpdate(JSON.parse(e.data).postId)
+      handlePostUpdate(JSON.parse(e.data))
     );
     eventSource.addEventListener('postUpdated', (e) =>
-      handlePostUpdate(JSON.parse(e.data).postId)
+      handlePostUpdate(JSON.parse(e.data))
     );
 
     return () => {

--- a/components/post/post-list/post-list.tsx
+++ b/components/post/post-list/post-list.tsx
@@ -118,7 +118,11 @@ export default function PostList({
       {staleEventSourcePosts.length > 0 && (
         <div className='sticky top-[84px] z-50'>
           <div className='flex justify-around mt-[-32px]'>
-            <div className='bg-base-100 p-xs rounded-full cursor-pointer'>
+            <div
+              className='bg-base-100 p-xs rounded-full cursor-pointer'
+              aria-live='polite'
+              aria-atomic='true'
+            >
               <IconButton
                 Icon={RepostIcon}
                 href='javascript:void(0);'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "autoprefixer": "10.4.15",
-        "clada-storybook": "^2.7.0",
+        "clada-storybook": "^2.8.0",
         "dotenv": "^16.4.5",
         "env-linter": "^2.0.0",
         "next": "^14.2.0",
@@ -1727,9 +1727,9 @@
       }
     },
     "node_modules/clada-storybook": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/clada-storybook/-/clada-storybook-2.7.0.tgz",
-      "integrity": "sha512-ZZdAW8ma7ikHM6cO0ZKzCvVMOf6M1kKruXFwqza4DK7osucaeVSjrGzWgyeAGWrv9C4kj76tVSAAvf37sARorA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/clada-storybook/-/clada-storybook-2.8.0.tgz",
+      "integrity": "sha512-EN8vLbUC0Cd/Qkdijf69sWeWL9YjlbrybtkCWHq9rjd09AnRw8qjfGH80hLlEkix5fsmE324Rbpvji7sIraN2A==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "@headlessui/tailwindcss": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "autoprefixer": "10.4.15",
-        "clada-storybook": "^2.6.1",
+        "clada-storybook": "^2.7.0",
         "dotenv": "^16.4.5",
         "env-linter": "^2.0.0",
         "next": "^14.2.0",
@@ -1727,9 +1727,9 @@
       }
     },
     "node_modules/clada-storybook": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/clada-storybook/-/clada-storybook-2.6.1.tgz",
-      "integrity": "sha512-2OGNAr8gn1yMEmRKHDjPDSfIJXBn1uuNdjdSsNUK0iOBTT8PZYu1ieePdiWUYTFuzR3kOULF4TCv/Vya9Xlulg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/clada-storybook/-/clada-storybook-2.7.0.tgz",
+      "integrity": "sha512-ZZdAW8ma7ikHM6cO0ZKzCvVMOf6M1kKruXFwqza4DK7osucaeVSjrGzWgyeAGWrv9C4kj76tVSAAvf37sARorA==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "@headlessui/tailwindcss": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "autoprefixer": "10.4.15",
-    "clada-storybook": "^2.7.0",
+    "clada-storybook": "^2.8.0",
     "dotenv": "^16.4.5",
     "env-linter": "^2.0.0",
     "next": "^14.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "autoprefixer": "10.4.15",
-    "clada-storybook": "^2.6.1",
+    "clada-storybook": "^2.7.0",
     "dotenv": "^16.4.5",
     "env-linter": "^2.0.0",
     "next": "^14.2.0",

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -22,3 +22,10 @@ export const getTimeDifferenceInMinutes = (ulid: string): number => {
 
   return Math.round(Math.abs(diffInMinutes));
 };
+
+export const isNewer = (ulid1: string, ulid2: string): boolean => {
+  const date1 = decodeULIDTimestamp(ulid1);
+  const date2 = decodeULIDTimestamp(ulid2);
+
+  return date1 > date2;
+};


### PR DESCRIPTION
## Enhancements to Accessibility in PostList Component

### Overview
This PR introduces an accessibility improvement to the `PostList` component. Specifically, it addresses the dynamic nature of the post feed where new posts can appear and a refresh button is dynamically displayed when new posts are detected via an event source. These changes aim to enhance the experience for screen reader users by making them aware of new content without disrupting their current interactions.

### Changes Made

#### ARIA Live Region for Refresh Button
- Implemented an `aria-live="polite"` attribute on the refresh button's container. This ensures that when the button is dynamically rendered, it will be announced by screen readers in a non-intrusive manner.
- Added `aria-atomic="true"` to make sure the whole content of the live region is announced as a single atomic update, rather than just the changed parts.

#### Revalidation Logic Using Session Storage
- Integrated session storage to manage the revalidation state. This change ensures that the component can remember to revalidate the posts upon the next component mount if it was marked before unmounting.

### Further Changes
- Using EventSource to set the revalidation flag in SessionStorage
- Ensured that all event listeners associated with post updates (like post creation, updates, likes, and deletions) properly update the session storage revalidation flag to reflect the need for data freshness.
